### PR TITLE
fix: update webpack config, add types folder, fix strings as constants

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "eslint-plugin-import": "^2.23.3",
         "eslint-plugin-prettier": "^3.4.0",
         "eslint-webpack-plugin": "^3.1.1",
+        "html-loader": "^3.1.0",
         "html-webpack-plugin": "^5.2.0",
         "prettier": "2.2.1",
         "style-loader": "^2.0.0",
@@ -3638,6 +3639,26 @@
       "integrity": "sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA==",
       "dev": true
     },
+    "node_modules/html-loader": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/html-loader/-/html-loader-3.1.0.tgz",
+      "integrity": "sha512-ycMYFRiCF7YANcLDNP72kh3Po5pTcH+bROzdDwh00iVOAY/BwvpuZ1BKPziQ35Dk9D+UD84VGX1Lu/H4HpO4fw==",
+      "dev": true,
+      "dependencies": {
+        "html-minifier-terser": "^6.0.2",
+        "parse5": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
+      }
+    },
     "node_modules/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -5445,6 +5466,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+      "dev": true
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -11302,6 +11329,16 @@
       "integrity": "sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA==",
       "dev": true
     },
+    "html-loader": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/html-loader/-/html-loader-3.1.0.tgz",
+      "integrity": "sha512-ycMYFRiCF7YANcLDNP72kh3Po5pTcH+bROzdDwh00iVOAY/BwvpuZ1BKPziQ35Dk9D+UD84VGX1Lu/H4HpO4fw==",
+      "dev": true,
+      "requires": {
+        "html-minifier-terser": "^6.0.2",
+        "parse5": "^6.0.1"
+      }
+    },
     "html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -12664,6 +12701,12 @@
       "requires": {
         "callsites": "^3.0.0"
       }
+    },
+    "parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+      "dev": true
     },
     "parseurl": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "clean-webpack-plugin": "^3.0.0",
     "copy-webpack-plugin": "^7.0.0",
     "css-loader": "^5.1.0",
+    "html-loader": "^3.1.0",
     "eslint": "^8.8.0",
     "eslint-config-airbnb-typescript": "^16.1.0",
     "eslint-config-prettier": "^8.3.0",

--- a/src/application/mainPage/navbar.ts
+++ b/src/application/mainPage/navbar.ts
@@ -15,20 +15,32 @@ export default class Navbar extends Control {
 
   navButtons: NodeListOf<ChildNode>;
 
+  private main: string = 'main';
+
+  private eBook: string = 'eBook';
+
+  private miniGames: string = 'miniGames';
+
+  private statistics: string = 'statistics';
+
+  private dictionary: string = 'dictionary';
+
+  private aboutTeam: string = 'aboutTeam';
+
   constructor(parentNode: HTMLElement) {
     super(parentNode, 'nav', 'navbar', '');
     this.toMainButton = new Control(this.node, 'button', 'nav-button', 'to Main');
-    this.toMainButton.node.id = 'main';
+    this.toMainButton.node.id = this.main;
     this.toEbookButton = new Control(this.node, 'button', 'nav-button', 'to E-Book');
-    this.toEbookButton.node.id = 'eBook';
+    this.toEbookButton.node.id = this.eBook;
     this.toMiniGamesButton = new Control(this.node, 'button', 'nav-button', 'to Mini Games');
-    this.toMiniGamesButton.node.id = 'miniGames';
+    this.toMiniGamesButton.node.id = this.miniGames;
     this.toStatisticsButton = new Control(this.node, 'button', 'nav-button', 'to Statistics');
-    this.toStatisticsButton.node.id = 'statistics';
+    this.toStatisticsButton.node.id = this.statistics;
     this.toDictionaryButton = new Control(this.node, 'button', 'nav-button', 'to Dictionary');
-    this.toDictionaryButton.node.id = 'dictionary';
+    this.toDictionaryButton.node.id = this.dictionary;
     this.toAboutTeamButton = new Control(this.node, 'button', 'nav-button', 'to About team');
-    this.toAboutTeamButton.node.id = 'aboutTeam';
+    this.toAboutTeamButton.node.id = this.aboutTeam;
     this.navButtons = this.node.childNodes;
   }
 }

--- a/src/application/router.ts
+++ b/src/application/router.ts
@@ -10,26 +10,38 @@ export default class Router {
 
   path: string = this.defaultPath;
 
+  private main: string = 'main';
+
+  private eBook: string = 'eBook';
+
+  private miniGames: string = 'miniGames';
+
+  private statistics: string = 'statistics';
+
+  private dictionary: string = 'dictionary';
+
+  private aboutTeam: string = 'aboutTeam';
+
   resolve(path?: string) {
     this.path = path || this.defaultPath;
     let resolved;
     switch (path) {
-      case 'main':
+      case this.main:
         resolved = MainSection;
         break;
-      case 'eBook':
+      case this.eBook:
         resolved = EBookSection;
         break;
-      case 'miniGames':
+      case this.miniGames:
         resolved = MiniGamesSection;
         break;
-      case 'statistics':
+      case this.statistics:
         resolved = StatisticsSection;
         break;
-      case 'dictionary':
+      case this.dictionary:
         resolved = DictionarySection;
         break;
-      case 'aboutTeam':
+      case this.aboutTeam:
         resolved = AboutTeamSection;
         break;
       default:

--- a/types/html.d.ts
+++ b/types/html.d.ts
@@ -1,0 +1,4 @@
+declare module '*.html' {
+  const value: string;
+  export default value;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,6 +30,10 @@ const baseConfig = {
         test: /\.(woff(2)?|eot|ttf|otf)$/i,
         type: 'asset/resource',
       },
+      {
+        test: /\.html$/i,
+        loader: "html-loader",
+      },
     ],
   },
   resolve: {


### PR DESCRIPTION
Add new rule to webpack.config:
{
        test: /\.html$/i,
        loader: "html-loader",
 },

Example of importing HTML and CSS files:
![image](https://user-images.githubusercontent.com/84184578/152568825-4ee09cc3-ce77-4cb1-8374-bf8be0a22256.png)
![image](https://user-images.githubusercontent.com/84184578/152569339-c3f3b710-f898-48f2-ab69-efb130e9cbad.png)
![image](https://user-images.githubusercontent.com/84184578/152569379-46db908e-36ab-4fbe-871d-f08da12874f1.png)
![image](https://user-images.githubusercontent.com/84184578/152569489-1bf07b52-69a9-4c82-9bcd-d29164bdc5b5.png)


